### PR TITLE
fix: compilation on windows with msvc (`MSVC` macro not defined)

### DIFF
--- a/SexyAppFramework/Common.h
+++ b/SexyAppFramework/Common.h
@@ -31,7 +31,7 @@
 #undef max
 
 // Define unreachable()
-#ifdef MSVC
+#ifdef _MSC_VER
 #define unreachable std::unreachable
 #else
 #define unreachable __builtin_unreachable

--- a/SexyAppFramework/graphics/D3D8Helper.cpp
+++ b/SexyAppFramework/graphics/D3D8Helper.cpp
@@ -184,7 +184,7 @@ typedef struct _D3DPRESENT_PARAMETERS_
 #define D3DADAPTER_DEFAULT                     0
 #define D3DENUM_NO_WHQL_LEVEL                   0x00000002L
 
-#ifndef MSVC
+#ifndef _MSC_VER
 #include <d3d8caps.h>
 #endif
 

--- a/SexyAppFramework/graphics/D3D8Helper.h
+++ b/SexyAppFramework/graphics/D3D8Helper.h
@@ -22,7 +22,7 @@ namespace Sexy
 
 #endif
 
-#ifdef MSVC
+#ifdef _MSC_VER
 // @Patoke todo: remove this
 /*==========================================================================;
  *


### PR DESCRIPTION
`MSVC` isn't defined, [`_MSC_VER` should be used](https://stackoverflow.com/a/5850405).

This is necessary for compilation with MSVC since `__builtin_unreachable` isn't a defined keyword (among other issues).